### PR TITLE
Add r.lsp.args to support customized startup arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,15 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VSIX_FILE: vscode-r-lsp.vsix
     steps:
       - uses: actions/checkout@v2
       - run: npm install
       - uses: lannonbr/vsce-action@master
         with:
-          args: "package -o vscode-r-lsp.vsix"
+          args: "package -o $VSIX_FILE"
       - uses: actions/upload-artifact@v1
         with:
-          name: vscode-r-lsp.vsix
-          path: vscode-r-lsp.vsix
+          name: $VSIX_FILE
+          path: $VSIX_FILE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: main
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "package -o vscode-r-lsp.vsix"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: vscode-r-lsp.vsix
+          path: vscode-r-lsp.vsix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
           args: "package -o $VSIX_FILE"
       - uses: actions/upload-artifact@v1
         with:
-          name: "$VSIX_FILE"
-          path: "$VSIX_FILE"
+          name: ${{ env.VSIX_FILE }}
+          path: ${{ env.VSIX_FILE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
           args: "package -o $VSIX_FILE"
       - uses: actions/upload-artifact@v1
         with:
-          name: $VSIX_FILE
-          path: $VSIX_FILE
+          name: "$VSIX_FILE"
+          path: "$VSIX_FILE"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ R LSP Client for [VS Code](https://code.visualstudio.com/), powered by the [R La
 This package exposes the following configuration options:
 
 - `r.lsp.path`: Path to R binary for launching the R Language Server package (see below). Examples: `/usr/bin/R` (Linux/macOS), `C:\\Program Files\\R\\R-3.5.2\\bin\\x64\\R.exe` (Windows).
+- `r.lsp.args`: The command line arguments to use when launching R Language Server. Example: `--vanilla` to disable loading startup scripts such as `.Rprofile` and `Rprofile.site`.
 - `r.lsp.debug`: Enable debugging traces. Defaults to `false`. Set this to `true` if you are having trouble getting the Language Server working.
 - `r.lsp.diagnostics`: Enable linting of R code, using the lintr package. Defaults to `true`. To disable this, you must have at least version 0.2.7 of the R Language Server installed.
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           "default": "",
           "description": "Path to R binary for launching Language Server"
         },
+        "r.lsp.args": {
+          "type": "array",
+          "default": [],
+          "description": "The command line arguments to use when launching R Language Server"
+        },
         "r.lsp.debug": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
Closes #34 

This PR adds a new option `r.lsp.args` to make it possible for user to customize the startup arguments of the R language server process in addition to `--quiet` and `--slave`.

For testing, a GitHub action to build package and upload artifact is also added.