### PR TITLE
Use multi-server to work with multi-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.1.7
+
+- Support multi-workspace ([#45](https://github.com/REditorSupport/vscode-r-lsp/pull/45)):
+  - Untilted documents share a server started from home folder.
+  - Each file outside workspaces uses a server started from parent folder.
+  - Each workspace uses a server started from the workspace folder.
+  - For `renv`-enabled project, user has to install `languageserver` into the project library,
+    or otherwise `r.lsp.args = [ "--no-init-file" ]` should be used to skip the project profile.
+
 ## 0.1.6
 
 - add a new setting `r.lsp.args` to support customized startup arguments (e.g. `--no-init-file`) of R language server ([#34](https://github.com/REditorSupport/vscode-r-lsp/issues/34))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r-lsp",
   "displayName": "R LSP Client",
   "description": "R LSP Client for VS Code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",
   "icon": "images/Rlogo.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,6 +142,8 @@ export function activate(context: ExtensionContext) {
                 clients.set(document.uri.toString(), client);
                 return;
             }
+
+            return;
         }
 
         // Each workspace share a client started from workspace folder

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,13 +3,13 @@ import { LanguageClient, LanguageClientOptions, StreamInfo } from 'vscode-langua
 import * as net from 'net';
 import * as url from 'url';
 import { getRPath } from './util'
-import { ExtensionContext, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window } from 'vscode';
+import { ExtensionContext, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder, DocumentSelector } from 'vscode';
 import os = require('os');
 
 let defaultClient: LanguageClient;
 let clients: Map<string, LanguageClient> = new Map();
 
-async function createClient(config: WorkspaceConfiguration, cwd: string, outputChannel: OutputChannel): Promise<LanguageClient> {
+async function createClient(config: WorkspaceConfiguration, cwd: string, workspaceFolder: WorkspaceFolder, outputChannel: OutputChannel): Promise<LanguageClient> {
     let client: LanguageClient;
 
     var debug = config.get("lsp.debug");
@@ -31,7 +31,10 @@ async function createClient(config: WorkspaceConfiguration, cwd: string, outputC
         console.log(str);
     }
 
-    const initArgs: string[] = config.get("lsp.args");
+    const options = { cwd: cwd, env: env };
+
+    let initArgs: string[] = [];
+    initArgs.push(config.get("lsp.args"));
     initArgs.push("--quiet", "--slave");
 
     const tcpServerOptions = () => new Promise<ChildProcess | StreamInfo>((resolve, reject) => {
@@ -55,7 +58,7 @@ async function createClient(config: WorkspaceConfiguration, cwd: string, outputC
             } else {
                 args = initArgs.concat(["-e", `languageserver::run(port=${port})`]);
             }
-            const childProcess = spawn(path, args, { cwd: cwd, env: env });
+            const childProcess = spawn(path, args, options);
             childProcess.stderr.on('data', (chunk: Buffer) => {
                 const str = chunk.toString();
                 console.log('R Language Server:', str);
@@ -71,27 +74,31 @@ async function createClient(config: WorkspaceConfiguration, cwd: string, outputC
         });
     });
 
+    let documentSelector;
+    if (workspaceFolder === undefined) {
+        documentSelector = [
+            { scheme: 'untitled', language: 'r' },
+            { scheme: 'untitled', language: 'rmd' }
+        ];
+    } else {
+        const pattern = `${workspaceFolder.uri.fsPath}/**/*`;
+        documentSelector = [
+            { scheme: 'file', language: 'r', pattern: pattern },
+            { scheme: 'file', language: 'rmd', pattern: pattern },
+        ];
+    }
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for php documents
-        documentSelector: [
-            { scheme: 'file', language: 'r' },
-            { scheme: 'file', language: 'rmd' },
-            { scheme: 'untitled', language: 'r' },
-            { scheme: 'untitled', language: 'rmd' }
-        ],
+        documentSelector: documentSelector,
         uriConverters: {
             // VS Code by default %-encodes even the colon after the drive letter
             // NodeJS handles it much better
             code2Protocol: uri => url.format(url.parse(uri.toString(true))),
             protocol2Code: str => Uri.parse(str)
         },
-        synchronize: {
-            // Synchronize the setting section 'r' to the server
-            configurationSection: 'r.lsp',
-            // Notify the server about changes to R files in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/*.r')
-        },
+        workspaceFolder: workspaceFolder,
         outputChannel: outputChannel,
     };
 
@@ -103,7 +110,7 @@ async function createClient(config: WorkspaceConfiguration, cwd: string, outputC
         } else {
             args = initArgs.concat(["-e", `languageserver::run()`]);
         }
-        client = new LanguageClient('R Language Server', { command: path, args: args, options: { cwd: cwd, env: env } }, clientOptions);
+        client = new LanguageClient('R Language Server', { command: path, args: args, options: options }, clientOptions);
     } else {
         client = new LanguageClient('R Language Server', tcpServerOptions, clientOptions);
     }
@@ -116,6 +123,7 @@ export function activate(context: ExtensionContext) {
     const outputChannel: OutputChannel = window.createOutputChannel('R Language Server');
 
     async function didOpenTextDocument(document: TextDocument) {
+        outputChannel.appendLine(document.uri.toString());
         if (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled') {
             return;
         }
@@ -127,7 +135,7 @@ export function activate(context: ExtensionContext) {
         const uri = document.uri;
         // Untitled files go to a default client.
         if (uri.scheme === 'untitled' && !defaultClient) {
-            defaultClient = await createClient(config, os.homedir(), outputChannel);
+            defaultClient = await createClient(config, os.homedir(), undefined, outputChannel);
             defaultClient.start();
             return;
         }
@@ -138,7 +146,7 @@ export function activate(context: ExtensionContext) {
         }
 
         if (!clients.has(folder.uri.toString())) {
-            let client = await createClient(config, folder.uri.fsPath, outputChannel);
+            let client = await createClient(config, folder.uri.fsPath, folder, outputChannel);
             client.start();
             clients.set(folder.uri.toString(), client);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ export function activate(context: ExtensionContext) {
         const folder = workspace.getWorkspaceFolder(document.uri);
         if (!folder) {
 
-            // All untitled documents share a client started from home folder
+            // All untitled documents share a server started from home folder
             if (document.uri.scheme === 'untitled' && !defaultClient) {
                 const documentSelector: DocumentFilter[] = [
                     { scheme: 'untitled', language: 'r' },
@@ -132,7 +132,7 @@ export function activate(context: ExtensionContext) {
                 return;
             }
 
-            // Each file outside workspace uses a client started from parent folder
+            // Each file outside workspace uses a server started from parent folder
             if (document.uri.scheme === 'file' && !clients.has(document.uri.toString())) {
                 const documentSelector: DocumentFilter[] = [
                     { scheme: 'file', pattern: document.uri.fsPath },
@@ -146,7 +146,7 @@ export function activate(context: ExtensionContext) {
             return;
         }
 
-        // Each workspace share a client started from workspace folder
+        // Each workspace uses a server started from the workspace folder
         if (!clients.has(folder.uri.toString())) {
             const pattern = `${folder.uri.fsPath}/**/*`;
             const documentSelector: DocumentFilter[] = [

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,33 @@
+import * as winreg from "winreg";
+import { WorkspaceConfiguration } from 'vscode';
+import { existsSync } from "fs";
+
+export async function getRPath(config: WorkspaceConfiguration) {
+  var path = config.get("lsp.path") as string;
+  if (path && existsSync(path)) {
+    return path;
+  }
+
+  if (process.platform === "win32") {
+    try {
+      const key = new winreg({
+        hive: winreg.HKLM,
+        key: '\\Software\\R-Core\\R'
+      });
+      const item: winreg.RegistryItem = await new Promise((c, e) =>
+        key.get('InstallPath', (err, result) => err ? e(err) : c(result)));
+
+      const rhome = item.value;
+      console.log("found R in registry:", rhome)
+
+      path = rhome + "\\bin\\R.exe";
+    } catch (e) {
+      path = ""
+    }
+    if (path && existsSync(path)) {
+      return path;
+    }
+  }
+
+  return "R";
+}


### PR DESCRIPTION
Close #44 
Close https://github.com/REditorSupport/languageserver/issues/272

This PR uses multi-server introduced at <https://github.com/Microsoft/vscode-extension-samples/tree/master/lsp-multi-server-sample> to handle the cases of zero, one, or multiple workspaces.

* Untilted documents share a server started from home folder.
* Each file outside workspaces uses a server started from parent folder.
* Each workspace uses a server started from the workspace folder.

Since user would edit a single file at a time, the resource consumption looks perfectly acceptable.

For renv-enabled project, user has to install languageserver into the project library.

As for the use case of #34 where user wants languageserver installed in user library to work, `r.lsp.args = [ "--no-init-file" ]` should be used to skip the project profile.

![Kapture 2020-07-23 at 9 58 54](https://user-images.githubusercontent.com/4662568/88300247-d80e5480-cd35-11ea-962c-5ac805e1d310.gif)
