### PR TITLE
Synchronize settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.8
+
+- Fix settings synchronization to allow disabling diagnostics ([#47](https://github.com/REditorSupport/vscode-r-lsp/pull/47))
+
 ## 0.1.7
 
 - Support multi-workspace ([#45](https://github.com/REditorSupport/vscode-r-lsp/pull/45), [#46](https://github.com/REditorSupport/vscode-r-lsp/pull/46)):

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r-lsp",
   "displayName": "R LSP Client",
   "description": "R LSP Client for VS Code",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",
   "icon": "images/Rlogo.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
         synchronize: {
             // Synchronize the setting section 'r' to the server
             configurationSection: 'r.lsp',
-        }
+        },
     };
 
     // Create the language client and start the client.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,10 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
         },
         workspaceFolder: workspaceFolder,
         outputChannel: outputChannel,
+        synchronize: {
+            // Synchronize the setting section 'r' to the server
+            configurationSection: 'r.lsp',
+        }
     };
 
     // Create the language client and start the client.


### PR DESCRIPTION
Close https://github.com/REditorSupport/languageserver/issues/315.

Recover the use of `synchronize` in language client options.