### PR TITLE
Fix stdio mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.9
+
+- Fix stdio mode under Linux and macOS ([#50](https://github.com/REditorSupport/vscode-r-lsp/pull/50))
+
 ## 0.1.8
 
 - Fix settings synchronization to allow disabling diagnostics ([#47](https://github.com/REditorSupport/vscode-r-lsp/pull/47))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r-lsp",
   "displayName": "R LSP Client",
   "description": "R LSP Client for VS Code",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",
   "icon": "images/Rlogo.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,10 +33,7 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
     }
 
     const options = { cwd: cwd, env: env };
-
-    let initArgs: string[] = [];
-    initArgs.push(config.get("lsp.args"));
-    initArgs.push("--quiet", "--slave");
+    const initArgs: string[] = config.get<string[]>("lsp.args").concat("--quiet", "--slave");
 
     const tcpServerOptions = () => new Promise<ChildProcess | StreamInfo>((resolve, reject) => {
         // Use a TCP socket because of problems with blocking STDIO


### PR DESCRIPTION
Close #49 

```typescript
let initArgs: string[] = [];
initArgs.push(config.get("lsp.args"));
initArgs.push("--quiet", "--slave");
```

results in the following command args:

```
["/usr/lib/R/bin/exec/R", "", "--quiet", "--slave", "-e", "languageserver::run(debug=TRUE)"]
```

the stdio could be stuck.

This PR fixes the command args to be

```
["/usr/lib/R/bin/exec/R", "--quiet", "--slave", "-e", "languageserver::run(debug=TRUE)"]
```

where the empty item is removed and the stdio works well now.

No idea why this empty item in command args could cause stdio to hang but it works now anyway.