### PR TITLE
Support notebook cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.11
+
+- Support notebook cells ([#59](https://github.com/REditorSupport/vscode-r-lsp/pull/59))
+- Closing all untitled documents will shutdown the shared language server.
+- Fix a bug that prevents the extension from starting a new language server for untitled document.
+
 ## 0.1.10
 
 - Fix multiple language server/clients created for a single workspace ([#53](https://github.com/REditorSupport/vscode-r-lsp/issues/53))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r-lsp",
-  "version": "0.1.6",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r-lsp",
   "displayName": "R LSP Client",
   "description": "R LSP Client for VS Code",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",
   "icon": "images/Rlogo.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import net = require('net');
 import url = require('url');
 import { spawn, ChildProcess } from 'child_process';
-import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, StreamInfo, DocumentFilter, ErrorAction, CloseAction } from 'vscode-languageclient';
 import { ExtensionContext, workspace, Uri, TextDocument, WorkspaceConfiguration, OutputChannel, window, WorkspaceFolder } from 'vscode';
 import { getRPath } from './util'
 
@@ -87,6 +87,10 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
         synchronize: {
             // Synchronize the setting section 'r' to the server
             configurationSection: 'r.lsp',
+        },
+        errorHandler: {
+            error: () => ErrorAction.Shutdown,
+            closed: () => CloseAction.DoNotRestart,
         },
     };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,9 +58,7 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
             const childProcess = spawn(path, args, options);
             client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) started`);
             childProcess.stderr.on('data', (chunk: Buffer) => {
-                const str = chunk.toString();
-                console.log(`R Language Server (${childProcess.pid}): ${str}`);
-                client.outputChannel.appendLine(str);
+                client.outputChannel.appendLine(chunk.toString());
             });
             childProcess.on('exit', (code, signal) => {
                 client.outputChannel.appendLine(`R Language Server (${childProcess.pid}) exited ` +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,9 +214,22 @@ export function activate(context: ExtensionContext) {
 
     async function didCloseTextDocument(document: TextDocument) {
         if (document.uri.scheme === 'untitled') {
-            return;
+            const result = workspace.textDocuments.find((doc) => doc.uri.scheme === 'untitled');
+            if (result) {
+                // Stop the langauge server when all untitled documents are closed.
+                return;
+            }
         }
 
+        if (document.uri.scheme === 'vscode-notebook-cell') {
+            const result = workspace.textDocuments.find((doc) => doc.uri.fsPath === document.uri.fsPath);
+            if (result) {
+                // Stop the language server when all cell documents are closed (notebook closed).
+                return;
+            }
+        }
+
+        // Stop the language server when single file outside workspace is closed, or the above cases.
         const key = getKey(document.uri);
         let client = clients.get(key);
         if (client) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,17 @@ function checkClient(name: string): boolean {
     return client && client.needsStop();
 }
 
+function getKey(uri: Uri) {
+    switch (uri.scheme) {
+        case 'untitled':
+            return uri.scheme;
+        case 'vscode-notebook-cell':
+            return `vscode-notebook:${uri.fsPath}`;
+        default:
+            return uri.toString();
+    }
+}
+
 export function activate(context: ExtensionContext) {
 
     const config = workspace.getConfiguration('r');
@@ -130,74 +141,84 @@ export function activate(context: ExtensionContext) {
 
         const folder = workspace.getWorkspaceFolder(document.uri);
         
+        // Each notebook uses a server started from parent folder
         if (document.uri.scheme === 'vscode-notebook-cell') {
-            if (!checkClient(document.uri.fsPath)) {
+            const key = getKey(document.uri);
+            if (!checkClient(key)) {
                 const documentSelector: DocumentFilter[] = [
                     { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}*` },
                 ];
                 let client = await createClient(config, documentSelector,
                     path.dirname(document.uri.fsPath), folder, outputChannel);
                 client.start();
-                clients.set(document.uri.fsPath, client);
-                initSet.delete(document.uri.fsPath);
+                clients.set(key, client);
+                initSet.delete(key);
                 return;
             }
 
             return;
         }
 
-        if (!folder) {
+        if (folder) {
+
+            // Each workspace uses a server started from the workspace folder
+            const key = getKey(folder.uri);
+            if (!checkClient(key)) {
+                const pattern = `${folder.uri.fsPath}/**/*`;
+                const documentSelector: DocumentFilter[] = [
+                    { scheme: 'file', language: 'r', pattern: pattern },
+                    { scheme: 'file', language: 'rmd', pattern: pattern },
+                ];
+                let client = await createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
+                client.start();
+                clients.set(key, client);
+                initSet.delete(key);
+            }
+
+        } else {
 
             // All untitled documents share a server started from home folder
-            if (document.uri.scheme === 'untitled' && !checkClient('untitled')) {
-                const documentSelector: DocumentFilter[] = [
-                    { scheme: 'untitled', language: 'r' },
-                    { scheme: 'untitled', language: 'rmd' },
-                ];
-                let client = await createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
-                client.start();
-                clients.set('untitled', client);
-                initSet.delete('untitled');
+            if (document.uri.scheme === 'untitled') {
+                const key = getKey(document.uri);
+                if (!checkClient(key)) {
+                    const documentSelector: DocumentFilter[] = [
+                        { scheme: 'untitled', language: 'r' },
+                        { scheme: 'untitled', language: 'rmd' },
+                    ];
+                    let client = await createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
+                    client.start();
+                    clients.set(key, client);
+                    initSet.delete(key);
+                }
+
                 return;
             }
 
             // Each file outside workspace uses a server started from parent folder
-            if (document.uri.scheme === 'file' && !checkClient(document.uri.toString())) {
-                const documentSelector: DocumentFilter[] = [
-                    { scheme: 'file', pattern: document.uri.fsPath },
-                ];
-                let client = await createClient(config, documentSelector,
-                    path.dirname(document.uri.fsPath), undefined, outputChannel);
-                client.start();
-                clients.set(document.uri.toString(), client);
-                initSet.delete(document.uri.toString());
+            if (document.uri.scheme === 'file') {
+                const key = getKey(document.uri);
+                if (!checkClient(key)) {
+                    const documentSelector: DocumentFilter[] = [
+                        { scheme: 'file', pattern: document.uri.fsPath },
+                    ];
+                    let client = await createClient(config, documentSelector,
+                        path.dirname(document.uri.fsPath), undefined, outputChannel);
+                    client.start();
+                    clients.set(key, client);
+                    initSet.delete(key);
+                }
+
                 return;
             }
-
-            return;
-        }
-
-        // Each workspace uses a server started from the workspace folder
-        if (!checkClient(folder.uri.toString())) {
-            const pattern = `${folder.uri.fsPath}/**/*`;
-            const documentSelector: DocumentFilter[] = [
-                { scheme: 'file', language: 'r', pattern: pattern },
-                { scheme: 'file', language: 'rmd', pattern: pattern },
-            ];
-            let client = await createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
-            client.start();
-            clients.set(folder.uri.toString(), client);
-            initSet.delete(folder.uri.toString());
         }
     }
 
     async function didCloseTextDocument(document: TextDocument) {
-        let key: string;
-        if (document.uri.scheme === 'vscode-notebook-cell') {
-            key = document.uri.fsPath;
-        } else {
-            key = document.uri.toString();
+        if (document.uri.scheme === 'untitled') {
+            return;
         }
+
+        const key = getKey(document.uri);
         let client = clients.get(key);
         if (client) {
             clients.delete(key);
@@ -210,9 +231,10 @@ export function activate(context: ExtensionContext) {
     workspace.textDocuments.forEach(didOpenTextDocument);
     workspace.onDidChangeWorkspaceFolders((event) => {
         for (let folder of event.removed) {
-            let client = clients.get(folder.uri.toString());
+            const key = getKey(folder.uri);
+            let client = clients.get(key);
             if (client) {
-                clients.delete(folder.uri.toString());
+                clients.delete(key);
                 client.stop()
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,6 @@ export function activate(context: ExtensionContext) {
                 client.start();
                 clients.set(key, client);
                 initSet.delete(key);
-                return;
             }
 
             return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,9 +150,8 @@ export function activate(context: ExtensionContext) {
                     path.dirname(document.uri.fsPath), folder, outputChannel);
                 client.start();
                 clients.set(key, client);
-                initSet.delete(key);
             }
-
+            initSet.delete(key);
             return;
         }
 
@@ -169,8 +168,8 @@ export function activate(context: ExtensionContext) {
                 let client = await createClient(config, documentSelector, folder.uri.fsPath, folder, outputChannel);
                 client.start();
                 clients.set(key, client);
-                initSet.delete(key);
             }
+            initSet.delete(key);
 
         } else {
 
@@ -185,8 +184,8 @@ export function activate(context: ExtensionContext) {
                     let client = await createClient(config, documentSelector, os.homedir(), undefined, outputChannel);
                     client.start();
                     clients.set(key, client);
-                    initSet.delete(key);
                 }
+                initSet.delete(key);
 
                 return;
             }
@@ -202,8 +201,8 @@ export function activate(context: ExtensionContext) {
                         path.dirname(document.uri.fsPath), undefined, outputChannel);
                     client.start();
                     clients.set(key, client);
-                    initSet.delete(key);
                 }
+                initSet.delete(key);
 
                 return;
             }
@@ -233,6 +232,7 @@ export function activate(context: ExtensionContext) {
         let client = clients.get(key);
         if (client) {
             clients.delete(key);
+            initSet.delete(key);
             client.stop();
         }
     }
@@ -246,6 +246,7 @@ export function activate(context: ExtensionContext) {
             let client = clients.get(key);
             if (client) {
                 clients.delete(key);
+                initSet.delete(key);
                 client.stop()
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,7 +222,8 @@ export function activate(context: ExtensionContext) {
         }
 
         if (document.uri.scheme === 'vscode-notebook-cell') {
-            const result = workspace.textDocuments.find((doc) => doc.uri.fsPath === document.uri.fsPath);
+            const result = workspace.textDocuments.find((doc) =>
+                doc.uri.scheme === document.uri.scheme && doc.uri.fsPath === document.uri.fsPath);
             if (result) {
                 // Stop the language server when all cell documents are closed (notebook closed).
                 return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export function activate(context: ExtensionContext) {
             const key = getKey(document.uri);
             if (!checkClient(key)) {
                 const documentSelector: DocumentFilter[] = [
-                    { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}*` },
+                    { scheme: 'vscode-notebook-cell', language: 'r', pattern: `${document.uri.fsPath}` },
                 ];
                 let client = await createClient(config, documentSelector,
                     path.dirname(document.uri.fsPath), folder, outputChannel);


### PR DESCRIPTION
Close https://github.com/Ikuyadeu/vscode-R/issues/396.

This PR makes R language server support the [Notebook API](https://code.visualstudio.com/api/extension-guides/notebook) out of the box.

A notebook is collection of cells, and each cell has a `TextDocument`. Therefore, we use an independent server for each notebook, just like how we handle files outside workspace.