### PR TITLE
Watch all R files in workspace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,6 +91,7 @@ async function createClient(config: WorkspaceConfiguration, selector: DocumentFi
         synchronize: {
             // Synchronize the setting section 'r' to the server
             configurationSection: 'r.lsp',
+            fileEvents: workspace.createFileSystemWatcher('**/*.{R,r}'),
         },
         revealOutputChannelOn: RevealOutputChannelOn.Never,
         errorHandler: {


### PR DESCRIPTION
See https://github.com/REditorSupport/languageserver/issues/446#issuecomment-871940326.

I did some testing and the glob pattern is case-sensitive on unix platforms. Therefore, I write it for both `r` and `R`.

It has no effect until the language server handles `workspace/didChangeWatchedFiles` notification.